### PR TITLE
Disable molmarker measure

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -304,7 +304,7 @@
         >
         </lens-chart>
       </div>
-      <div class="chart-wrapper chart-wrapper-mol">
+      <!-- <div class="chart-wrapper chart-wrapper-mol">
         <lens-chart
           title="MolecularMarkers"
           dataKey="MolecularMarkers"
@@ -313,7 +313,7 @@
           backgroundColor={barChartBackgroundColors}
         >
         </lens-chart>
-      </div>
+      </div> -->
     </div>
   </div>
 </main>

--- a/src/lib/measures.ts
+++ b/src/lib/measures.ts
@@ -346,5 +346,5 @@ export const measures: FhirMeasureItem[] = [
   dktkProceduresMeasure,
   dktkMedicationStatementsMeasure,
   dktkHistologyMeasure,
-  dktkMonoObservationMeasure,
+  // dktkMonoObservationMeasure,
 ];


### PR DESCRIPTION
Adding mol markers now requires adding the stratifier to focus so disabling for now.